### PR TITLE
Update InternalsVisibleToSourceGenerator.cs

### DIFF
--- a/src/Infrastructure.SourceGenerators.InternalsVisibleTo/InternalsVisibleToSourceGenerator.cs
+++ b/src/Infrastructure.SourceGenerators.InternalsVisibleTo/InternalsVisibleToSourceGenerator.cs
@@ -55,9 +55,11 @@ public class InternalsVisibleToSourceGenerator : ISourceGenerator
   private string[] GetInternalsVisibleToAssemblies (GeneratorExecutionContext context)
   {
     var globalOptions = context.AnalyzerConfigOptions.GlobalOptions;
-    return globalOptions.TryGetValue(c_internalsVisibleToAssembliesConfigKey, out var configValue)
-        ? configValue.Split(',')
-        : Array.Empty<string>();
+
+    if (globalOptions.TryGetValue(c_internalsVisibleToAssembliesConfigKey, out var configValue))
+      return configValue.Split(',');
+
+    return Array.Empty<string>();
   }
 
   private string FormatInternalsVisibleToAttribute (string assemblyName, string publicKey)


### PR DESCRIPTION
Aside from the blank lines, the IF-syntax isn't any longer than the ternary operator and reduces the statement complexity. I know, null isn't likely, but a null ref happening either due to globalObjects or configValue wouldn't be understandable when it's just one long statement.